### PR TITLE
Development activation backward compatibility

### DIFF
--- a/ng-pkgs/activation_service/actors/activation_service.py
+++ b/ng-pkgs/activation_service/actors/activation_service.py
@@ -37,10 +37,10 @@ class ActivationService(BaseActor):
             try:
                 if "address" in args:
                     address = args.get("address", None)
+                else:
+                    raise j.exceptions.Value(f"missing a required argument: 'address' in args dict")
             except j.data.serializers.json.json.JSONDecodeError:
                 pass
-            if not address:
-                raise j.exceptions.Value(f"missing a required argument: 'address' in args dict")
 
         try:
             self._activate_account(address)


### PR DESCRIPTION
## Changes
1. Add backward compatibility for activation service to take either 
    - `{"address":<address>} `
OR like in jsx version
    - `{"args":{"address":<address>}}`

2. remove "args" from response

## Related issue 
https://github.com/threefoldfoundation/tft-stellar/issues/199