### PR TITLE
Update activation and txfunding services to be used on the same server

### DIFF
--- a/ThreeBotPackages/activation_service/package.py
+++ b/ThreeBotPackages/activation_service/package.py
@@ -31,36 +31,6 @@ class activation_service:
 
         set_wallet(wallet)
 
-        if "default_443" in j.sals.nginx.main.websites.list_all():
-            location_actors_443 = j.sals.nginx.main.websites.default_443.locations.get(name="activation_actors")
-            location_actors_443.is_auth = False
-            location_actors_443.is_admin = False
-            location_actors_443.save()
-
-        if "default_80" in j.sals.nginx.main.websites.list_all():
-            location_actors_80 = j.sals.nginx.main.websites.default_80.locations.get(name="activation_actors")
-            location_actors_80.is_auth = False
-            location_actors_80.is_admin = False
-            location_actors_80.save()
-
-        # Configure server domain (passed as kwargs if not, will be the default domain in package.toml)
-        if "domain" in kwargs:
-            domain = kwargs.get("domain")
-            toml_config = toml.load(j.sals.fs.join_paths(j.sals.fs.dirname(__file__), "package.toml"))
-            package_name = toml_config["name"]
-            server_name = toml_config["servers"][0]["name"]
-
-            j.sals.nginx.main.websites.get(f"{package_name}_{server_name}_443").domain = domain
-            j.sals.nginx.main.websites.get(f"{package_name}_{server_name}_443").configure()
-            j.sals.nginx.main.websites.get(f"{package_name}_{server_name}_80").domain = domain
-            j.sals.nginx.main.websites.get(f"{package_name}_{server_name}_80").configure()
-
-        if "default_443" in j.sals.nginx.main.websites.list_all():
-            j.sals.nginx.main.websites.default_443.configure()
-
-        if "default_80" in j.sals.nginx.main.websites.list_all():
-            j.sals.nginx.main.websites.default_80.configure()
-
         create_gevent_pool()
 
     def start(self, **kwargs):

--- a/ThreeBotPackages/activation_service/package.toml
+++ b/ThreeBotPackages/activation_service/package.toml
@@ -1,15 +1,10 @@
 name = "activation_service"
 is_auth = false
 is_admin = false
-
-
-[[servers]]
-name = "activation_root_proxy"
 domain = "testnet.threefoldtoken.io"
 letsencryptemail = "tarekr@incubaid.com"
-includes = ["default_443.activation*"]
 
-[[servers.locations]]
+[[locations]]
 name = "custom"
 type = "custom"
 custom_config = """

--- a/ThreeBotPackages/transactionfunding_service/package.py
+++ b/ThreeBotPackages/transactionfunding_service/package.py
@@ -47,36 +47,6 @@ class transactionfunding_service:
         nr_of_slaves = kwargs.get("slaves", 30)
         ensure_slavewallets(nr_of_slaves)
 
-        if "default_443" in j.sals.nginx.main.websites.list_all():
-            location_actors_443 = j.sals.nginx.main.websites.default_443.locations.get(name="transactionfunding_actors")
-            location_actors_443.is_auth = False
-            location_actors_443.is_admin = False
-            location_actors_443.save()
-
-        if "default_80" in j.sals.nginx.main.websites.list_all():
-            location_actors_80 = j.sals.nginx.main.websites.default_80.locations.get(name="transactionfunding_actors")
-            location_actors_80.is_auth = False
-            location_actors_80.is_admin = False
-            location_actors_80.save()
-
-        # Configure server domain (passed as kwargs if not, will be the default domain in package.toml)
-        if "domain" in kwargs:
-            domain = kwargs.get("domain")
-            toml_config = toml.load(j.sals.fs.join_paths(j.sals.fs.dirname(__file__), "package.toml"))
-            package_name = toml_config["name"]
-            server_name = toml_config["servers"][0]["name"]
-
-            j.sals.nginx.main.websites.get(f"{package_name}_{server_name}_443").domain = domain
-            j.sals.nginx.main.websites.get(f"{package_name}_{server_name}_443").configure()
-            j.sals.nginx.main.websites.get(f"{package_name}_{server_name}_80").domain = domain
-            j.sals.nginx.main.websites.get(f"{package_name}_{server_name}_80").configure()
-
-        if "default_443" in j.sals.nginx.main.websites.list_all():
-            j.sals.nginx.main.websites.default_443.configure()
-
-        if "default_80" in j.sals.nginx.main.websites.list_all():
-            j.sals.nginx.main.websites.default_80.configure()
-
         start_funding_loop()
 
     def start(self, **kwargs):

--- a/ThreeBotPackages/transactionfunding_service/package.toml
+++ b/ThreeBotPackages/transactionfunding_service/package.toml
@@ -1,15 +1,10 @@
 name = "transactionfunding_service"
 is_auth = false
 is_admin = false
-
-
-[[servers]]
-name = "transactionfunding_root_proxy"
 domain = "testnet.threefoldtoken.io"
 letsencryptemail = "tarekr@incubaid.com"
-includes = ["default_443.transactionfunding*"]
 
-[[servers.locations]]
+[[locations]]
 name = "custom"
 type = "custom"
 custom_config = """


### PR DESCRIPTION
### Description

The default server will be used instead of custom servers for each of the services packages. The is_admin and is_auth of the default server will then be applied and will include the custom locations and the actors locations

Based on PR https://github.com/threefoldtech/js-sdk/pull/2203 being merged

### Changes
- Default server will include the custom rewrite locations instead of an individual one for each package
- is_admin and is_auth with values false of the default will be used
- **WARNING** To be able to use the domain it needs to be passed when starting the threebot server as the domain of the server , it is no longer attached to these packages. Therefore both packages will use the same domain that is to be passed to the threebot server when starting 

### Related Issues

- https://github.com/threefoldfoundation/tft-stellar/issues/262 