### PR TITLE
Refactor unlock service import script

### DIFF
--- a/ThreeBotPackages/unlock_service/scripts/jsng_import.py
+++ b/ThreeBotPackages/unlock_service/scripts/jsng_import.py
@@ -1,34 +1,29 @@
 import click
 import os
 import sys
-
+import requests
 from jumpscale.loader import j
 from jumpscale.core.base import StoredFactory
 
-current_full_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(current_full_path + "/../models/")
-from models import UnlockhashTransaction
 
-unlock_transaction_hash_model = StoredFactory(UnlockhashTransaction)
-unlock_transaction_hash_model.always_reload = True
+UNLOCK_SERVICE_DEFAULT_HOST = "https://testnet.threefoldtoken.io"
 
 
 @click.command()
 @click.option("--destination", default="/unlockhash_transaction_data", help="Destination to import data from")
-def import_unlockhash_transaction_data(destination):
-
+@click.option("--unlock_service_host", default=UNLOCK_SERVICE_DEFAULT_HOST, help="Destination to import data from")
+def import_unlockhash_transaction_data(destination, unlock_service_host):
     file_content = j.sals.fs.read_file(destination)
     file_content = file_content.replace("'", "")
     unlockhash_transactions_list = j.data.serializers.json.loads(file_content)
     for unlockhash_transaction_data in unlockhash_transactions_list:
         unlockhash = unlockhash_transaction_data.get("unlockhash")
         transaction_xdr = unlockhash_transaction_data.get("transaction_xdr")
-        unlockhash_transaction = unlock_transaction_hash_model.new(unlockhash)
 
-        unlockhash_transaction.unlockhash = unlockhash
-        unlockhash_transaction.transaction_xdr = transaction_xdr
-
-        unlockhash_transaction.save()
+        requests.post(
+            f"{unlock_service_host}/threefoldfoundation/unlock_service/create_unlockhash_transaction",
+            json={"unlockhash": unlockhash, "transaction_xdr": transaction_xdr},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use requests to save imported unlockhash transactions using unlock service instead of storedfactory

Issue:
https://github.com/threefoldfoundation/tft-stellar/issues/276