### PR TITLE
Add getting vesting dashboard services network from kwargs

### DIFF
--- a/ThreeBotPackages/vesting_dashboard/package.py
+++ b/ThreeBotPackages/vesting_dashboard/package.py
@@ -1,4 +1,5 @@
 from jumpscale.loader import j
+import os
 
 wallet_name = "vesting_temp_wallet"
 
@@ -9,8 +10,9 @@ class vesting_dashboard:
         wallet = None
         wallet_name = "vesting_temp_wallet"  # Only to be used to check balance of other wallets, no need to activate
         if "vesting_temp_wallet" not in j.clients.stellar.list_all():
-            wallet_network = kwargs.get("wallet_network", "STD")
-            print(wallet_network)
+            wallet_network = kwargs.get("wallet_network", None)
+            if not wallet_network:
+                wallet_network = os.environ.get("TFT_SERVICES_NETWORK", "STD")
             wallet = j.clients.stellar.new(wallet_name, network=wallet_network)
             wallet.save()
 


### PR DESCRIPTION
## Description
If network is not  passed in kwargs when installing the package, it isto get it from the env variable `TFT_SERVICES_NETWORK`, otherwise it will fallback to using STD network

## Related Issues
https://github.com/threefoldfoundation/tft-stellar/issues/308