### PR TITLE
Add vesting stats to statistics service

### DIFF
--- a/ThreeBotPackages/tft_statistics/bottle/tft_statistics.py
+++ b/ThreeBotPackages/tft_statistics/bottle/tft_statistics.py
@@ -19,7 +19,7 @@ app = Bottle()
 
 
 def get_cache_time():
-    caching_time = os.environ.get("TFT_STATISTICS_CACHINGTIME", "600")
+    caching_time = os.environ.get("TFTSTATISTICS_CACHETIME", "600")
     return int(caching_time)
 
 
@@ -49,6 +49,7 @@ def get_stats():
     res["total_tokens"] = f"{stats['total']:,.7f}"
     res["total_accounts"] = f"{stats['num_accounts']}"
     res["total_locked_tokens"] = f"{stats['total_locked']:,.7f}"
+    res["total_vested_tokens"] = f"{stats['total_vested']:,.7f}"
     if detailed:
         res["locked_tokens_info"] = []
         for locked_amount in stats["locked"]:
@@ -98,7 +99,8 @@ def total_unlocked_tft():
 
     total_tft = stats["total"]
     total_locked_tft = stats["total_locked"]
-    total_unlocked_tft = total_tft - total_locked_tft
+    total_vested_tft = stats["total_vested"]
+    total_unlocked_tft = total_tft - total_locked_tft - total_vested_tft
 
     redis.set(f"{network}-{tokencode}-total_unlocked_tft", total_unlocked_tft, ex=get_cache_time())
     return f"{total_unlocked_tft}"

--- a/lib/stats/stats.py
+++ b/lib/stats/stats.py
@@ -181,10 +181,10 @@ class StatisticsCollector(object):
         stats["total_locked"] = total_locked
 
         # Calculate total vesting ammounts
-        total_vesting = 0.0
+        total_vested = 0.0
         for vesting_account in vesting_accounts:
-            total_vesting += vesting_account["amount"]
-        stats["total_vested_tokens"] = total_vesting
+            total_vested += vesting_account["amount"]
+        stats["total_vested"] = total_vested
         if not detailed:
             return stats
         amounts_per_locktime = {}
@@ -225,15 +225,14 @@ def show_stats(tokencode, network, detailed):
     print(f"Total amount of tokens: {stats['total']:,.7f}")
     print(f"Number of accounts: {stats['num_accounts']}")
     print(f"Amount of locked tokens: {stats['total_locked']:,.7f}")
-    print(f"Amount of vested tokens: {stats['total_vested_tokens']:,.7f}")
+    print(f"Amount of vested tokens: {stats['total_vested']:,.7f}")
     if detailed:
         for locked_amount in stats["locked"]:
             print(
                 f"{locked_amount['amount']:,.7f} locked until {datetime.datetime.fromtimestamp(locked_amount['until'])}"
             )
-    print(f"Amount of vesting tokens: {stats['total_vesting']:,.7f}")
     if detailed and stats["vesting"]:
-        print("Vesting accound details")
+        print("Vesting accounts details")
         for vesting_account in stats["vesting"]:
             print(
                 f"Vesting Account {vesting_account['account']} has {vesting_account['amount']} with scheme {vesting_account['scheme']}"

--- a/lib/stats/stats.py
+++ b/lib/stats/stats.py
@@ -191,7 +191,7 @@ class StatisticsCollector(object):
         total_vesting = 0.0
         for vesting_account in vesting_accounts:
             total_vesting += vesting_account["amount"]
-        stats["total_vesting"] = total_vesting
+        stats["total_vested_tokens"] = total_vesting
         if not detailed:
             return stats
         amounts_per_locktime = {}
@@ -232,7 +232,7 @@ def show_stats(tokencode, network, detailed):
     print(f"Total amount of tokens: {stats['total']:,.7f}")
     print(f"Number of accounts: {stats['num_accounts']}")
     print(f"Amount of locked tokens: {stats['total_locked']:,.7f}")
-    print(f"Amount of vesting tokens: {stats['total_vesting']:,.7f}")
+    print(f"Amount of vested tokens: {stats['total_vested_tokens']:,.7f}")
     if detailed:
         for locked_amount in stats["locked"]:
             print(

--- a/lib/stats/stats.py
+++ b/lib/stats/stats.py
@@ -120,31 +120,24 @@ def get_locked_accounts(network, tokencode: str):
                 and b["asset_issuer"] == issuer
             ]
             tokenbalance = tokenbalances[0] if tokenbalances else 0
+
+            if VESTING_DATA_ENTRY_KEY in account["data"]:
+                vesting_scheme = base64.b64decode((account["data"][VESTING_DATA_ENTRY_KEY])).decode("utf-8")
+                vesting_accounts.append(
+                    {
+                        "account": account_id,
+                        "amount": tokenbalance,
+                        "preauth_signers": preauth_signers,
+                        "scheme": vesting_scheme,
+                    }
+                )
+                continue
+
             if len(preauth_signers) > 0:
                 locked_accounts.append(
                     {"account": account_id, "amount": tokenbalance, "preauth_signers": preauth_signers}
                 )
 
-            if VESTING_DATA_ENTRY_KEY in account["data"]:
-                vesting_scheme = base64.b64decode((account["data"][VESTING_DATA_ENTRY_KEY])).decode("utf-8")
-                preauth_signers = [signer["key"] for signer in account["signers"] if signer["type"] == "preauth_tx"]
-                vesting_tokenbalances = [
-                    float(b["balance"])
-                    for b in account["balances"]
-                    if b["asset_type"] == "credit_alphanum4"
-                    and b["asset_code"] == tokencode
-                    and b["asset_issuer"] == issuer
-                ]
-                vesting_tokenbalance = vesting_tokenbalances[0] if vesting_tokenbalances else 0
-                if len(preauth_signers) > 0:
-                    vesting_accounts.append(
-                        {
-                            "account": account_id,
-                            "amount": vesting_tokenbalance,
-                            "preauth_signers": preauth_signers,
-                            "scheme": vesting_scheme,
-                        }
-                    )
     return locked_accounts, vesting_accounts
 
 


### PR DESCRIPTION
## Description
Add vesting account details fetching and printing in tft stats service

## Related Issue
https://github.com/threefoldfoundation/tft-stellar/issues/289

## Sample output
```
Gathering statistics for TFT on the public network
Total amount of tokens: 554,054,770.0911427
Number of accounts: 8429
Amount of locked tokens: 255,313,900.0218578
Amount of vesting tokens: 7,123,145.5168849
700,333.9472008 locked until 2021-01-01 00:00:00
2.0000000 locked until 2021-01-04 16:35:47
.
.
.
Amount of vesting tokens: 7,123,145.5168849
Vesting accound details
Vesting Account GA2SPNODXZSU6ZVX3X3PN552RL5MTA5CELKTIV2YNSJQ27R5GOAN5JKT has 0.0 with scheme month1=05/2021,48months,priceunlock=tftvalue>month*0.015+0.15
Vesting Account GADJCWNY5RBX6CR6EIS4FP7YP6TZ3QMT63ZPUB3QUU7DSO77USWHXAUU has 500000.0 with scheme month1=05/2021,48months,priceunlock=tftvalue>month*0.015+0.15
.
.
.
.
```